### PR TITLE
chore: set up GitHub actions to run unit tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Unit tests on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check bash shell version
+        run: bash --version
+      - name: Unit tests (file pattern-check)
+        run: TERM='xterm-256color' bash pattern-check

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Vim Tmux Navigator
 ==================
 
+[![GitHub Actions](https://img.shields.io/github/actions/workflow/status/christoomey/vim-tmux-navigator/main.yml?style=flat-square&logo=github)](https://github.com/christoomey/vim-tmux-navigator/actions/workflows/main.yml)
+
 This plugin is a repackaging of [Mislav Marohnić's](https://mislav.net/) tmux-navigator
 configuration described in [this gist][]. When combined with a set of tmux
 key bindings, the plugin will allow you to navigate seamlessly between


### PR DESCRIPTION
No change to logic. This sets up GitHub Actions CI to run the pattern-check unit test script before and after PRs are merged.

Test: checks are active starting with this PR, so check out the results